### PR TITLE
improve puppet error checks

### DIFF
--- a/puppet/check_puppet.rb
+++ b/puppet/check_puppet.rb
@@ -89,7 +89,7 @@ if File.exists?(summaryfile)
             total_failure = true
         else
             # and unless there are failures, the events hash just wont have the failure count
-            failcount = summary["events"]["failure"] || 0
+            failcount = 0 + summary["events"]["failure"] + summary["resources"]["failed"]
         end
     rescue
         failcount = 0


### PR DESCRIPTION
Nicer to have this as a single Nagios check instead of 2. Also count failed resource as failures since this don't get reported under events (what's the difference?).
