### PR TITLE
added perfdata option and modified output text

### DIFF
--- a/puppet/check_puppet.rb
+++ b/puppet/check_puppet.rb
@@ -26,6 +26,7 @@ crit = 0
 total_failure = false
 enabled_only = false
 failures = false
+disable_perfdata = false
 
 opt = OptionParser.new
 
@@ -55,6 +56,10 @@ end
 
 opt.on("--summary-file [FILE]", "-s", "Location of the summary file, default #{summaryfile}") do |f|
     summaryfile = f
+end
+
+opt.on("--disable-perfdata", "-x", "Disable performance data output") do |f|
+    disable_perfdata = f
 end
 
 opt.parse!
@@ -97,54 +102,67 @@ end
 
 time_since_last_run = Time.now.to_i - lastrun
 
+time_since_last_run_string = "#{time_since_last_run} seconds ago"
+if time_since_last_run >= 3600
+  time_since_last_run_string = "#{time_since_last_run / 60 / 60} hours ago at #{Time.at(Time.now + time_since_last_run).utc.strftime('%R:%S')} UTC"
+elsif time_since_last_run >= 60
+  time_since_last_run_string = "#{time_since_last_run / 60} minutes ago"
+end
+
+if disable_perfdata
+  perfdata_time = ""
+else
+  perfdata_time = "|time_since_last_run=#{time_since_last_run}s;#{warn};#{crit};0 failed_resources=#{failcount};;;0"
+end
+
 unless failures
     if enabled_only && enabled == false
-        puts "OK: Puppet is currently disabled, not alerting.  Last run #{time_since_last_run} seconds ago with #{failcount} failures"
+        puts "OK: Puppet is currently disabled, not alerting.  Last run #{time_since_last_run_string} with #{failcount} failures#{perfdata_time}"
         exit 0
     end
 
     if total_failure
-        puts "CRITICAL: FAILED - Puppet failed to run. Missing dependencies? Catalog compilation failed? Puppet last ran #{time_since_last_run} seconds ago"
+        puts "CRITICAL: FAILED - Puppet failed to run. Missing dependencies? Catalog compilation failed? Last run #{time_since_last_run_string}#{perfdata_time}"
         exit 2
     elsif time_since_last_run >= crit
-        puts "CRITICAL: Puppet last ran #{time_since_last_run} seconds ago, expected < #{crit}"
+        puts "CRITICAL: last run #{time_since_last_run_string}, expected < #{crit}s#{perfdata_time}"
         exit 2
 
     elsif time_since_last_run >= warn
-        puts "WARNING: Puppet last ran #{time_since_last_run} seconds ago, expected < #{warn}"
+        puts "WARNING: last run #{time_since_last_run_string}, expected < #{warn}s#{perfdata_time}"
         exit 1
 
     else
         if enabled
-            puts "OK: Puppet is currently enabled, last run #{time_since_last_run} seconds ago with #{failcount} failures"
+            puts "OK: last run #{time_since_last_run_string} with #{failcount} failures and currently enabled#{perfdata_time}"
         else
-            puts "OK: Puppet is currently disabled, last run #{time_since_last_run} seconds ago with #{failcount} failures"
+            puts "OK: last run #{time_since_last_run_string} with #{failcount} failures and currently disabled#{perfdata_time}"
         end
 
         exit 0
     end
 else
     if enabled_only && enabled == false
-        puts "OK: Puppet is currently disabled, not alerting.  Last run #{time_since_last_run} seconds ago with #{failcount} failures"
+        puts "OK: Puppet is currently disabled, not alerting.  Last run #{time_since_last_run_string} with #{failcount} failures#{perfdata_time}"
         exit 0
     end
 
     if total_failure
-        puts "CRITICAL: FAILED - Puppet failed to run. Missing dependencies? Catalog compilation failed? Puppet last ran #{time_since_last_run} seconds ago"
+        puts "CRITICAL: FAILED - Puppet failed to run. Missing dependencies? Catalog compilation failed? Last run #{time_since_last_run_string}#{perfdata_time}"
         exit 2
     elsif failcount >= crit
-        puts "CRITICAL: Puppet last ran had #{failcount} failures, expected < #{crit}"
+        puts "CRITICAL: Puppet last ran had #{failcount} failures, expected < #{crit}#{perfdata_time}"
         exit 2
 
     elsif failcount >= warn
-        puts "WARNING: Puppet last ran had #{failcount} failures, expected < #{warn}"
+        puts "WARNING: Puppet last ran had #{failcount} failures, expected < #{warn}#{perfdata_time}"
         exit 1
 
     else
         if enabled
-            puts "OK: Puppet is currently enabled, last run #{time_since_last_run} seconds ago with #{failcount} failures"
+            puts "OK: last run #{time_since_last_run_string} with #{failcount} failures and currently enabled#{perfdata_time}"
         else
-            puts "OK: Puppet is currently disabled, last run #{time_since_last_run} seconds ago with #{failcount} failures"
+            puts "OK: last run #{time_since_last_run_string} with #{failcount} failures and currently disabled#{perfdata_time}"
         end
 
         exit 0


### PR DESCRIPTION
Added -x, --print-performance option that appends performance data about the puppet run to the output.

Also modified the output text to display the time since the last puppet run in minutes or in hours with the time.
