### PR TITLE
support putting reason for disabling puppet into lock file

### DIFF
--- a/puppet/check_puppet.rb
+++ b/puppet/check_puppet.rb
@@ -28,6 +28,7 @@ total_failure = false
 enabled_only = false
 failures = false
 disable_perfdata = false
+lockfile_contents = nil
 
 opt = OptionParser.new
 
@@ -74,7 +75,12 @@ if File.exists?(lockfile)
     if File::Stat.new(lockfile).zero?
        enabled = false
     else
-       running = true
+       lockfile_contents = File.read(lockfile).chomp
+       if lockfile_contents =~ /^\d+$/
+         running = true
+       else
+         enabled = false
+       end
     end
 end
 
@@ -139,6 +145,8 @@ unless failures
     else
         if enabled
             puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently enabled#{perfdata_time}"
+        elsif lockfile_contents
+            puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled (#{lockfile_contents})#{perfdata_time}"
         else
             puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled#{perfdata_time}"
         end
@@ -165,6 +173,8 @@ else
     else
         if enabled
             puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently enabled#{perfdata_time}"
+        elsif lockfile_contents
+            puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled (#{lockfile_contents})#{perfdata_time}"
         else
             puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled#{perfdata_time}"
         end


### PR DESCRIPTION
We use a little script to update the puppet lock file with the reason for disabling puppet so this shows up in nagios.

I was shopping for an updated nagios check that would use values from the last_run_summary.yaml file but we wanted to maintain the mentioned functionality.