### PR TITLE
JSON-less. Add reason for disabling puppet to output messages

### DIFF
--- a/puppet/check_puppet.rb
+++ b/puppet/check_puppet.rb
@@ -99,7 +99,7 @@ end
 
 if File.exists?(agent_disabled_lockfile)
     enabled = false
-    disabled_message = File.open('/var/lib/puppet/state/agent_disabled.lock', 'r').read.gsub(/.*\"(.*)\"\}/, '\1') || "reason not specified"
+    disabled_message = File.open(agent_disabled_lockfile, 'r').read.gsub(/.*\"(.*)\"\}/, '\1') || "reason not specified"
 end
 
 

--- a/puppet/check_puppet.rb
+++ b/puppet/check_puppet.rb
@@ -34,6 +34,7 @@ total_failure = false
 enabled_only = false
 failures = false
 disable_perfdata = false
+disabled_message = "reason not specified"
 
 opt = OptionParser.new
 
@@ -98,6 +99,7 @@ end
 
 if File.exists?(agent_disabled_lockfile)
     enabled = false
+    disabled_message = File.open('/var/lib/puppet/state/agent_disabled.lock', 'r').read.gsub(/.*\"(.*)\"\}/, '\1') || "reason not specified"
 end
 
 
@@ -147,7 +149,7 @@ end
 
 unless failures
     if enabled_only && enabled == false
-        puts "OK: Puppet is currently disabled, not alerting. Last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events#{perfdata_time}"
+        puts "OK: Puppet is currently disabled, not alerting. Last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events. Disabled with reason: #{disabled_message}#{perfdata_time}"
         exit 0
     end
 
@@ -166,7 +168,7 @@ unless failures
         if enabled
             puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently enabled#{perfdata_time}"
         else
-            puts "WARNING: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled#{perfdata_time}"
+            puts "WARNING: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled with reason: #{disabled_message}#{perfdata_time}"
             exit 1
          end
 
@@ -174,7 +176,7 @@ unless failures
     end
 else
     if enabled_only && enabled == false
-        puts "OK: Puppet is currently disabled, not alerting. Last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events#{perfdata_time}"
+        puts "OK: Puppet is currently disabled, not alerting. Last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events. Disabled with reason: #{disabled_message}#{perfdata_time}"
         exit 0
     end
 
@@ -193,7 +195,7 @@ else
         if enabled
             puts "OK: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently enabled#{perfdata_time}"
         else
-            puts "WARNING: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled#{perfdata_time}"
+            puts "WARNING: last run #{time_since_last_run_string} with #{failcount_resources} failed resources #{failcount_events} failed events and currently disabled with reason: #{disabled_message}#{perfdata_time}"
             exit 1
         end
 


### PR DESCRIPTION
This is an alternate implementation of #9 and #14 by reading the agent_disabled lockfile which is written by puppet when you execute the `puppet agent --disable` command without requiring the JSON gem. This is not perfect since it's using a regex to match the string inside the lockfile.

@ripienaar I'm still not a Ruby pro :smile: 