### PR TITLE
Puppet 4 Compatibility

### DIFF
--- a/puppet/check_puppet.rb
+++ b/puppet/check_puppet.rb
@@ -17,7 +17,8 @@
 require 'optparse'
 require 'yaml'
 
-statedir = "/var/lib/puppet/state"
+puppet_maj_version = `puppet --version`[0].to_i
+puppet_maj_version >= 4 ? statedir = "/opt/puppetlabs/puppet/cache/state" : statedir = "/var/lib/puppet/state"
 agent_lockfile = statedir + "/agent_catalog_run.lock"
 agent_disabled_lockfile = statedir + "/agent_disabled.lock"
 statefile = statedir + "/state.yaml"


### PR DESCRIPTION
`check_puppet.rb` requires an update to the `statedir` variable when upgrading to Puppet 4 - the rest seems to work as-is.  

 - [x] add and test adjustment to be forward/backward compatible  
 - [x] ready for review/merge  