### PR TITLE
Puppet 4 Compatibility

### DIFF
--- a/puppet/check_puppet.rb
+++ b/puppet/check_puppet.rb
@@ -17,7 +17,9 @@
 require 'optparse'
 require 'yaml'
 
-statedir = "/var/lib/puppet/state"
+statedir_puppet_3 = "/var/lib/puppet/state"
+statedir_puppet_4 = "/opt/puppetlabs/puppet/cache/state"
+File.directory?(statedir_puppet_4) ? statedir = statedir_puppet_4 : statedir = statedir_puppet_3
 agent_lockfile = statedir + "/agent_catalog_run.lock"
 agent_disabled_lockfile = statedir + "/agent_disabled.lock"
 statefile = statedir + "/state.yaml"


### PR DESCRIPTION
Replacement for PR https://github.com/ripienaar/monitoring-scripts/pull/18 - please see previous PR for comments/reviews.  

`check_puppet.rb` requires an update to the `statedir` variable when upgrading to Puppet 4 - the rest seems to work as-is. I've put the Puppet 4 `statedir` path into a variable as I've seen paths and features change over time as Puppet 4 has developed.  

 - [x] add and test adjustment to be forward/backward compatible  
 - [x] ready for review/merge  